### PR TITLE
style: lint, format + manual adjustments

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -314,10 +314,7 @@ class EventDispatcher:
     def movement_lock(self) -> MovementLock:
         if self.patterning_busy or self.autofocus_busy:
             return MovementLock.LOCKED
-        elif (
-            self.shown_image == ShownImage.UV_FOCUS
-            or self.shown_image == ShownImage.PATTERN
-        ):
+        elif self.shown_image in (ShownImage.UV_FOCUS, ShownImage.PATTERN):
             return MovementLock.XY_LOCKED
         else:
             return MovementLock.UNLOCKED
@@ -339,11 +336,8 @@ class EventDispatcher:
 
     def begin_patterning(self) -> None:
         # TODO: Update patterning preview
-
         print("Patterning at ", self.stage_setpoint)
-
         duration = self.exposure_time
-
         print(f"Patterning 1 tiles for {duration}ms\nTotal time: {str(round((duration) / 1000))}s")
 
         # TODO: Image slicing.
@@ -416,9 +410,7 @@ class EventDispatcher:
             return
 
         print("Starting autofocus")
-
         self.set_autofocus_busy(True)
-
         self.non_blocking_delay(2.0)
 
         last_focus = self.focus_score
@@ -442,9 +434,7 @@ class EventDispatcher:
             last_focus = self.focus_score
 
         self.move_relative({"z": -2.0})
-
         self.set_autofocus_busy(False)
-
         print("Finished autofocus")
 
     def set_snapshot_directory(self, directory: Path) -> None:
@@ -478,9 +468,7 @@ class SnapshotFrame:
             self.counter += 1
             self._refresh_name_preview()
 
-        self.button = ttk.Button(
-            self.frame, text="Take Snapshot", command=on_snapshot_button
-        )
+        self.button = ttk.Button(self.frame, text="Take Snapshot", command=on_snapshot_button)
         self.button.grid(row=0, column=2)
 
         self._refresh_name_preview()
@@ -564,27 +552,21 @@ class StagePositionFrame:
         self.z_widgets: list[ttk.Widget] = []
 
         # Absolute
-
         self.absolute_frame = ttk.LabelFrame(self.frame, text="Stage Position")
         self.absolute_frame.grid(row=0, column=0)
 
         for i, coord in ((0, "x"), (1, "y"), (2, "z")):
-            self.position_intputs.append(
-                IntEntry(parent=self.absolute_frame, default=0)
-            )
+            self.position_intputs.append(IntEntry(parent=self.absolute_frame, default=0))
             self.position_intputs[-1].widget.grid(row=0, column=i)
 
         def callback_set() -> None:
             x, y, z = self._position()
             event_dispatcher.move_absolute({"x": x, "y": y, "z": z})
 
-        self.set_position_button = ttk.Button(
-            self.absolute_frame, text="Set Stage Position", command=callback_set
-        )
+        self.set_position_button = ttk.Button(self.absolute_frame, text="Set Stage Position", command=callback_set)
         self.set_position_button.grid(row=1, column=0, columnspan=3, sticky="ew")
 
         # Relative
-
         self.relative_frame = ttk.LabelFrame(self.frame, text="Adjustment")
         self.relative_frame.grid(row=1, column=0)
 
@@ -682,27 +664,21 @@ class ImageAdjustFrame:
         self.lockable_widgets: list[ttk.Widget] = []
 
         # Absolute
-
         self.absolute_frame = ttk.LabelFrame(self.frame, text="Image Adjustment")
         self.absolute_frame.grid(row=0, column=0)
 
         for i, coord in ((0, "x"), (1, "y"), (2, "ϴ")):
-            self.position_intputs.append(
-                IntEntry(parent=self.absolute_frame, default=0)
-            )
+            self.position_intputs.append(IntEntry(parent=self.absolute_frame, default=0))
             self.position_intputs[-1].widget.grid(row=0, column=i)
 
         def callback_set() -> None:
             x, y, t = self._position()
             event_dispatcher.set_image_position(x, y, t)
 
-        self.set_position_button = ttk.Button(
-            self.absolute_frame, text="Set Image Position", command=callback_set
-        )
+        self.set_position_button = ttk.Button(self.absolute_frame, text="Set Image Position", command=callback_set)
         self.set_position_button.grid(row=1, column=0, columnspan=3, sticky="ew")
 
         # Relative
-
         self.relative_frame = ttk.LabelFrame(self.frame, text="Adjustment")
         self.relative_frame.grid(row=1, column=0)
 
@@ -799,17 +775,12 @@ class MultiImageSelectFrame:
         self.frame = ttk.Frame(parent)
 
         def get_name(path: str) -> str:
-            if path == "":
-                return ""
-            else:
-                return Path(path).name
+          return "" if path == "" else Path(path).name
 
         self.pattern_frame = ImageSelectFrame(
             self.frame,
             "Pattern",
-            lambda t: event_dispatcher.set_pattern_image(
-                self.pattern_image(), get_name(self.pattern_frame.thumb.path)
-            ),
+            lambda t: event_dispatcher.set_pattern_image(self.pattern_image(), get_name(self.pattern_frame.thumb.path)),
         )
         self.red_focus_frame = ImageSelectFrame(
             self.frame,
@@ -848,13 +819,9 @@ class ExposureFrame:
 
         self.frame.columnconfigure(0, weight=1)
 
-        ttk.Label(self.frame, text="Exposure Time (ms)", anchor="w").grid(
-            row=0, column=0
-        )
+        ttk.Label(self.frame, text="Exposure Time (ms)", anchor="w").grid(row=0, column=0)
         self.exposure_time_entry = IntEntry(self.frame, default=8000, min_value=0)
-        self.exposure_time_entry.widget.grid(
-            row=0, column=1, columnspan=2, sticky="nesw"
-        )
+        self.exposure_time_entry.widget.grid(row=0, column=1, columnspan=2, sticky="nesw")
 
         def on_exposure_time_change(_a, _b, _c):
             event_dispatcher.exposure_time = self.exposure_time_entry._var.get()
@@ -914,9 +881,7 @@ class PatterningFrame:
     def __init__(self, parent: ttk.Frame, event_dispatcher: EventDispatcher) -> None:
         self.frame = ttk.Frame(parent)
 
-        self.preview_tile = ttk.Label(
-            self.frame, text="Next Pattern Tile", compound="top"
-        )  # type:ignore
+        self.preview_tile = ttk.Label(self.frame, text="Next Pattern Tile", compound="top")  # type:ignore
         self.preview_tile.grid(row=0, column=0)
 
         self.begin_patterning_button = ttk.Button(
@@ -935,12 +900,8 @@ class PatterningFrame:
         )
         self.abort_patterning_button.grid(row=2, column=0)
 
-        ttk.Label(self.frame, text="Exposure Progress", anchor="s").grid(
-            row=3, column=0
-        )
-        self.exposure_progress = Progressbar(
-            self.frame, orient="horizontal", mode="determinate", maximum=1000
-        )
+        ttk.Label(self.frame, text="Exposure Progress", anchor="s").grid(row=3, column=0)
+        self.exposure_progress = Progressbar(self.frame, orient="horizontal", mode="determinate", maximum=1000)
         self.exposure_progress.grid(row=4, column=0, sticky="ew")
 
         self.set_image(Image.new("RGB", (1, 1)))
@@ -957,9 +918,7 @@ class PatterningFrame:
         event_dispatcher.add_event_listener(Event.PATTERN_IMAGE_CHANGED, lambda: self.set_image(event_dispatcher.pattern.processed()))
 
         def on_progress_changed():
-            self.exposure_progress["value"] = (
-                event_dispatcher.exposure_progress * 1000.0
-            )
+            self.exposure_progress["value"] = event_dispatcher.exposure_progress * 1000.0
 
         event_dispatcher.add_event_listener(Event.EXPOSURE_PATTERN_PROGRESS_CHANGED, on_progress_changed)
 
@@ -1042,10 +1001,7 @@ class ModeSelectFrame:
         # event_dispatcher.add_event_listener(Event.EnterUvMode, lambda: on_tab_event(Event.EnterUvMode))
 
     def _current_tab(self) -> str:
-        if "redmode" in self.notebook.select():
-            return "red"
-        else:
-            return "uv"
+      return "red" if "redmode" in self.notebook.select() else "uv"
 
 
 class GlobalSettingsFrame:
@@ -1053,9 +1009,7 @@ class GlobalSettingsFrame:
         self.frame = ttk.LabelFrame(parent, text="Global Settings")
 
         def set_value(*_):
-            event_dispatcher.autofocus_on_mode_switch = (
-                self.autofocus_on_mode_switch_var.get()
-            )
+            event_dispatcher.autofocus_on_mode_switch = self.autofocus_on_mode_switch_var.get()
 
         self.autofocus_on_mode_switch_var = BooleanVar(value=True)
         self.autofocus_on_mode_switch_check = ttk.Checkbutton(
@@ -1067,9 +1021,7 @@ class GlobalSettingsFrame:
 
         self.autofocus_on_mode_switch_var.trace_add("write", set_value)
 
-        self.autofocus_button = ttk.Button(
-            self.frame, text="Autofocus", command=lambda: event_dispatcher.autofocus()
-        )
+        self.autofocus_button = ttk.Button(self.frame, text="Autofocus", command=lambda: event_dispatcher.autofocus())
         self.autofocus_button.grid(row=1, column=0, columnspan=2, sticky="ew")
 
         # Maybe this should have a scale?
@@ -1077,9 +1029,7 @@ class GlobalSettingsFrame:
         self.border_size_var = IntVar()
         self.border_label = ttk.Label(self.frame, text="Border Size (%)")
         self.border_label.grid(row=2, column=0)
-        self.border_entry = IntEntry(
-            self.frame, var=self.border_size_var, default=0, min_value=0, max_value=100
-        )
+        self.border_entry = IntEntry(self.frame, var=self.border_size_var, default=0, min_value=0, max_value=100)
         self.border_entry.widget.grid(row=2, column=1, sticky="nesw")
 
         def on_border_size_change(*_):
@@ -1087,9 +1037,7 @@ class GlobalSettingsFrame:
 
         self.border_size_var.trace_add("write", on_border_size_change)
 
-        self.placeholder_photo = image_to_tk_image(
-            Image.new("RGB", THUMBNAIL_SIZE, "black")
-        )
+        self.placeholder_photo = image_to_tk_image(Image.new("RGB", THUMBNAIL_SIZE, "black"))
         self.photo = None
 
         self.current_image = ttk.Label(self.frame, image=self.placeholder_photo)  # type:ignore
@@ -1109,9 +1057,7 @@ class GlobalSettingsFrame:
             if img is None:
                 self.current_image.configure(image=self.placeholder_photo)  # type:ignore
             else:
-                photo = image_to_tk_image(
-                    img.resize(THUMBNAIL_SIZE, Image.Resampling.NEAREST)
-                )
+                photo = image_to_tk_image(img.resize(THUMBNAIL_SIZE, Image.Resampling.NEAREST))
                 self.current_image.configure(image=photo)  # type:ignore
                 self.photo = photo
 
@@ -1150,9 +1096,7 @@ class GlobalSettingsFrame:
                 event_dispatcher.set_snapshot_directory(Path(dir_path))
                 self.directory_var.set(dir_path)
 
-        self.choose_dir_button = ttk.Button(
-            self.snapshot_frame, text="Choose Directory", command=choose_directory
-        )
+        self.choose_dir_button = ttk.Button(self.snapshot_frame, text="Choose Directory", command=choose_directory)
         self.choose_dir_button.grid(row=2, column=0, columnspan=2, sticky="ew")
 
         # Configure grid weights for proper expansion
@@ -1162,9 +1106,7 @@ class GlobalSettingsFrame:
 class ExposureHistoryFrame:
     def __init__(self, parent: ttk.Frame, event_dispatcher: EventDispatcher) -> None:
         self.frame = ttk.LabelFrame(parent, text="Exposure History")
-        self.text = tkinter.Text(
-            self.frame, width=80, height=10, wrap="none", state="disabled"
-        )
+        self.text = tkinter.Text(self.frame, width=80, height=10, wrap="none", state="disabled")
         self.text.grid(row=0, column=0)
 
         self.event_dispatcher = event_dispatcher
@@ -1185,19 +1127,9 @@ class ExposureHistoryFrame:
 
 
 class LithographerGui:
-    root: Tk
-
-    # flatfield_image: ProcessedImage
-
-    event_dispatcher: EventDispatcher
-
-    def __init__(
-        self, stage: StageController, camera: CameraModule, title: str = "Lithographer"
-    ) -> None:
+    def __init__(self, stage: StageController, camera: CameraModule) -> None:
         self.root = Tk()
-        self.event_dispatcher = EventDispatcher(
-            stage, TkProjector(self.root), self.root
-        )
+        self.event_dispatcher = EventDispatcher(stage, TkProjector(self.root), self.root)
         self.shown_image = ShownImage.CLEAR
 
         # Create main panels
@@ -1224,9 +1156,7 @@ class LithographerGui:
         self.mode_select_frame = ModeSelectFrame(panel, self.event_dispatcher)
         self.mode_select_frame.notebook.grid(row=0, column=2)
 
-        self.multi_image_select_frame = MultiImageSelectFrame(
-            panel, self.event_dispatcher
-        )
+        self.multi_image_select_frame = MultiImageSelectFrame(panel, self.event_dispatcher)
         self.multi_image_select_frame.frame.grid(row=0, column=0)
 
         return panel

--- a/src/gui.py
+++ b/src/gui.py
@@ -46,8 +46,6 @@ class PatterningStatus(StrAutoEnum):
   PATTERNING = auto()
   ABORTING = auto()
 
-OnShownImageChange = Callable[[ShownImage], None]
-
 class Event(StrAutoEnum):
   """Events that can be dispatched to listeners"""
   SNAPSHOT = auto()

--- a/src/gui.py
+++ b/src/gui.py
@@ -30,14 +30,12 @@ THUMBNAIL_SIZE: tuple[int, int] = (160, 90)
 
 class StrAutoEnum(str, Enum):
     """Base class for string-valued enums that use auto()"""
-
     def _generate_next_value_(name, *_):
         return name.lower()
 
 
 class ShownImage(StrAutoEnum):
     """The type of image currently being displayed by the projector"""
-
     CLEAR = auto()
     PATTERN = auto()
     FLATFIELD = auto()
@@ -47,7 +45,6 @@ class ShownImage(StrAutoEnum):
 
 class PatterningStatus(StrAutoEnum):
     """The current state of the patterning process"""
-
     IDLE = auto()
     PATTERNING = auto()
     ABORTING = auto()
@@ -55,7 +52,6 @@ class PatterningStatus(StrAutoEnum):
 
 class Event(StrAutoEnum):
     """Events that can be dispatched to listeners"""
-
     SNAPSHOT = auto()
     SHOWN_IMAGE_CHANGED = auto()
     STAGE_POSITION_CHANGED = auto()
@@ -68,7 +64,6 @@ class Event(StrAutoEnum):
 
 class MovementLock(StrAutoEnum):
     """Controls whether stage position can be manually adjusted"""
-
     UNLOCKED = auto()  # X, Y, and Z are free to move
     XY_LOCKED = auto() # Only Z (focus) is free to move to avoid smearing UV focus pattern
     LOCKED = auto()  # No positions can move to avoid disrupting patterning
@@ -76,7 +71,6 @@ class MovementLock(StrAutoEnum):
 
 class RedFocusSource(StrAutoEnum):
     """The source image to use for red focus mode"""
-
     IMAGE = auto()  # Uses the dedicated red focus image
     SOLID = auto()  # Shows a solid red screen
     PATTERN = auto()  # Uses the blue channel from the pattern image
@@ -131,9 +125,7 @@ class EventDispatcher:
 
         self.exposure_history: list[ExposureLog] = []
 
-        self.add_event_listener(
-            Event.SHOWN_IMAGE_CHANGED, lambda: self._update_projector()
-        )
+        self.add_event_listener(Event.SHOWN_IMAGE_CHANGED, lambda: self._update_projector())
 
     @property
     def current_image(self) -> Optional[Image.Image]:
@@ -188,9 +180,7 @@ class EventDispatcher:
 
     def _refresh_red_focus(self) -> None:
         if self.hardware.projector.size() != self.solid_red_image.size:
-            self.solid_red_image = Image.new(
-                "RGB", self.hardware.projector.size(), "red"
-            )
+            self.solid_red_image = Image.new("RGB", self.hardware.projector.size(), "red")
 
         img = self._red_focus_source()
 
@@ -354,9 +344,7 @@ class EventDispatcher:
 
         duration = self.exposure_time
 
-        print(
-            f"Patterning 1 tiles for {duration}ms\nTotal time: {str(round((duration) / 1000))}s"
-        )
+        print(f"Patterning 1 tiles for {duration}ms\nTotal time: {str(round((duration) / 1000))}s")
 
         # TODO: Image slicing.
         # Note that flatfield correction and image adjustment should be applied *after* slicing
@@ -475,9 +463,7 @@ class SnapshotFrame:
 
         # TODO: Allow %X, %Y, %Z formats to save position on chip
         self.name_var = StringVar(value="output_%T.png")
-        self.name_var.trace_add(
-            "write", lambda _a, _b, _c: self._refresh_name_preview()
-        )
+        self.name_var.trace_add("write", lambda _a, _b, _c: self._refresh_name_preview())
 
         self.counter = 0
 
@@ -525,9 +511,7 @@ class CameraFrame:
 
         self.event_dispatcher = event_dispatcher
         self.snapshots_pending: queue.Queue = queue.Queue()
-        self.event_dispatcher.add_event_listener(
-            Event.SNAPSHOT, lambda filename: self.snapshots_pending.put(filename)
-        )
+        self.event_dispatcher.add_event_listener(Event.SNAPSHOT, lambda filename: self.snapshots_pending.put(filename))
 
         self.gui_img = None
         self.camera = camera
@@ -675,9 +659,7 @@ class StagePositionFrame:
             for i in range(3):
                 self.position_intputs[i].set(pos[i])
 
-        event_dispatcher.add_event_listener(
-            Event.STAGE_POSITION_CHANGED, on_position_change
-        )
+        event_dispatcher.add_event_listener(Event.STAGE_POSITION_CHANGED, on_position_change)
 
     def _position(self) -> tuple[int, int, int]:
         return tuple(intput.get() for intput in self.position_intputs)
@@ -776,9 +758,7 @@ class ImageAdjustFrame:
             for i in range(3):
                 self.position_intputs[i].set(pos[i])
 
-        event_dispatcher.add_event_listener(
-            Event.IMAGE_ADJUST_CHANGED, on_position_change
-        )
+        event_dispatcher.add_event_listener(Event.IMAGE_ADJUST_CHANGED, on_position_change)
 
         def on_lock_change() -> None:
             if event_dispatcher.movement_lock == MovementLock.UNLOCKED:
@@ -846,10 +826,7 @@ class MultiImageSelectFrame:
         self.red_focus_frame.frame.grid(row=1, column=0)
         self.uv_focus_frame.frame.grid(row=1, column=1)
 
-        event_dispatcher.add_event_listener(
-            Event.SHOWN_IMAGE_CHANGED,
-            lambda: self.highlight_button(event_dispatcher.shown_image),
-        )
+        event_dispatcher.add_event_listener(Event.SHOWN_IMAGE_CHANGED, lambda: self.highlight_button(event_dispatcher.shown_image))
 
     def pattern_image(self) -> Image.Image:
         return self.pattern_frame.thumb.image
@@ -976,22 +953,15 @@ class PatterningFrame:
                 self.begin_patterning_button["state"] = "normal"
                 self.abort_patterning_button["state"] = "disabled"
 
-        event_dispatcher.add_event_listener(
-            Event.PATTERNING_BUSY_CHANGED, on_change_patterning_status
-        )
-        event_dispatcher.add_event_listener(
-            Event.PATTERN_IMAGE_CHANGED,
-            lambda: self.set_image(event_dispatcher.pattern.processed()),
-        )
+        event_dispatcher.add_event_listener(Event.PATTERNING_BUSY_CHANGED, on_change_patterning_status)
+        event_dispatcher.add_event_listener(Event.PATTERN_IMAGE_CHANGED, lambda: self.set_image(event_dispatcher.pattern.processed()))
 
         def on_progress_changed():
             self.exposure_progress["value"] = (
                 event_dispatcher.exposure_progress * 1000.0
             )
 
-        event_dispatcher.add_event_listener(
-            Event.EXPOSURE_PATTERN_PROGRESS_CHANGED, on_progress_changed
-        )
+        event_dispatcher.add_event_listener(Event.EXPOSURE_PATTERN_PROGRESS_CHANGED, on_progress_changed)
 
     def set_image(self, img: Image.Image) -> None:
         # TODO: What is the correct size?
@@ -1132,9 +1102,7 @@ class GlobalSettingsFrame:
             else:
                 self.autofocus_button.configure(state="normal")
 
-        event_dispatcher.add_event_listener(
-            Event.MOVEMENT_LOCK_CHANGED, movement_lock_changed
-        )
+        event_dispatcher.add_event_listener(Event.MOVEMENT_LOCK_CHANGED, movement_lock_changed)
 
         def shown_image_changed():
             img = event_dispatcher.current_image
@@ -1147,9 +1115,7 @@ class GlobalSettingsFrame:
                 self.current_image.configure(image=photo)  # type:ignore
                 self.photo = photo
 
-        event_dispatcher.add_event_listener(
-            Event.SHOWN_IMAGE_CHANGED, shown_image_changed
-        )
+        event_dispatcher.add_event_listener(Event.SHOWN_IMAGE_CHANGED, shown_image_changed)
 
         self.snapshot_frame = ttk.LabelFrame(self.frame, text="Snapshot Settings")
         self.snapshot_frame.grid(row=4, column=0, columnspan=2, sticky="ew", pady=5)
@@ -1203,9 +1169,7 @@ class ExposureHistoryFrame:
 
         self.event_dispatcher = event_dispatcher
 
-        event_dispatcher.add_event_listener(
-            Event.PATTERNING_BUSY_CHANGED, lambda: self._refresh()
-        )
+        event_dispatcher.add_event_listener(Event.PATTERNING_BUSY_CHANGED, lambda: self._refresh())
 
     def _refresh(self) -> None:
         self.text["state"] = "normal"

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,28 +1,29 @@
-import serial
+import queue
+import time
+import tkinter
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum, auto
+from functools import partial
+from pathlib import Path
+from tkinter import BooleanVar, IntVar, StringVar, Tk, filedialog, messagebox, ttk
+from tkinter.ttk import Progressbar
+from typing import Callable, Optional
 
 import cv2
 import numpy as np
-import time
-import queue
-from pathlib import Path
-from dataclasses import dataclass
-from datetime import datetime
-from functools import partial
-from hardware import Lithographer, ImageProcessSettings, ProcessedImage
-from typing import Callable, Optional
+import serial
+import toml  # Need to use a package because we're stuck on Python 3.10
 from PIL import Image
+
 from camera.camera_module import CameraModule
 from camera.webcam import Webcam
-from stage_control.stage_controller import StageController
-from stage_control.grbl_stage import GrblStage
-from projector import ProjectorController, TkProjector
-from enum import Enum, auto
+from hardware import ImageProcessSettings, Lithographer, ProcessedImage
 from lib.gui import IntEntry, Thumbnail
 from lib.img import image_to_tk_image
-from tkinter.ttk import Progressbar
-from tkinter import ttk, Tk, BooleanVar, IntVar, StringVar, messagebox, filedialog
-import toml  # Need to use a package because we're stuck on Python 3.10
-import tkinter
+from projector import ProjectorController, TkProjector
+from stage_control.grbl_stage import GrblStage
+from stage_control.stage_controller import StageController
 
 # TODO: Don't hardcode
 THUMBNAIL_SIZE: tuple[int, int] = (160, 90)

--- a/src/gui.py
+++ b/src/gui.py
@@ -137,18 +137,15 @@ class EventDispatcher:
       self.hardware.projector.show(img)
 
   def _refresh_pattern(self) -> None:
-    self.pattern.update(image=self.pattern_image, settings=ImageProcessSettings(
+    process_settings = ImageProcessSettings(
       posterization=self.posterize_strength,
-      color_channels=(False, False, True),
       flatfield=None,
-      size=self.hardware.projector.size(),
+      color_channels=(False, False, True),
       image_adjust=self.image_adjust_position,
       border_size=self.border_size,
-      #size=self.pattern_image.size,
-      #flatfield=None,
-      #image_adjust=(0.0, 0.0, 0.0),
-      #border_size=0.0,
-    ))
+      size=self.hardware.projector.size(),
+    )
+    self.pattern.update(image=self.pattern_image, settings=process_settings)
 
     if self.red_focus_source == RedFocusSource.PATTERN:
       self._refresh_red_focus()
@@ -177,27 +174,29 @@ class EventDispatcher:
 
     img = self._red_focus_source()
 
-    self.red_focus.update(image=img, settings=ImageProcessSettings(
+    process_settings = ImageProcessSettings(
       posterization=self.posterize_strength,
       flatfield=None,
       color_channels=(True, False, False),
-      size=self.hardware.projector.size(),
       image_adjust=self.image_adjust_position,
       border_size=self.border_size,
-    ))
+      size=self.hardware.projector.size(),
+    )
+    self.red_focus.update(image=img, settings=process_settings)
 
     if self.shown_image == ShownImage.RED_FOCUS:
       self.on_event(Event.SHOWN_IMAGE_CHANGED)
   
   def _refresh_uv_focus(self) -> None:
-    self.uv_focus.update(image=self.uv_focus_image, settings=ImageProcessSettings(
+    process_settings = ImageProcessSettings(
       posterization=self.posterize_strength,
       flatfield=None,
       color_channels=(False, False, True),
-      size=self.hardware.projector.size(),
       image_adjust=self.image_adjust_position,
       border_size=0.0,
-    ))
+      size=self.hardware.projector.size(),
+    )
+    self.uv_focus.update(image=self.uv_focus_image, settings=process_settings)
 
     if self.shown_image == ShownImage.UV_FOCUS:
       self.on_event(Event.SHOWN_IMAGE_CHANGED)


### PR DESCRIPTION
I make a number of style changes:
- adding more type hints
- grouping `EventDispatcher` properties more explicitly and logically
- removing unused globals and imports

and lint and format the code with ruff.

I think this reads better and is easier to work with.