### PR TITLE
Fix homing and create better GRBL stage boundary error/alarm handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 *.mp3
 
 # configuration
-config.toml
+*.toml
 
 # python
 .venv

--- a/README.md
+++ b/README.md
@@ -219,7 +219,13 @@ uv-exposure = 25000.0
 # Set enabled to false to disable all motion.
 enabled = true
 # Set homing to false if your stage does not have limit sensors
-homing = true
+homing = false
+# Enable tiling if user wishes to use tiling features
+tiling = false
+# Set autofocus offset, requires homing to be true. Set 0 for no autofocus 
+autofocus = 0
+
+
 # Select the correct serial port for the device running GRBL.
 # The correct serial port can be checked with Device Manager on Windows.
 port = "COM6"

--- a/default.toml
+++ b/default.toml
@@ -20,9 +20,17 @@ uv-exposure = 25000.0
 # This section configures the motion stage
 [stage]
 # Set enabled to false to disable all motion.
-enabled = false
+enabled = true
+
 # Set homing to false if your stage does not have limit sensors
 homing = false
+
+# Enable tiling if user wishes to use tiling features
+tiling = false
+
+# Set autofocus offset, requires homing to be true. Set 0 for no autofocus 
+autofocus = 0
+
 # Select the correct serial port for the device running GRBL.
 # The correct serial port can be checked with Device Manager on Windows.
 port = "COM6"

--- a/src/gui.py
+++ b/src/gui.py
@@ -278,7 +278,7 @@ class EventDispatcher:
         self.red_focus_source = RedFocusSource.IMAGE
 
         # Stage control
-        self.stage_setpoint = (0.0, 0.0, 0.0)
+        self.stage_setpoint = (0.0,0.0,0.0)
 
         # Status flags
         self.shown_image = ShownImage.CLEAR
@@ -442,21 +442,95 @@ class EventDispatcher:
         self.shown_image = shown_image
         self.on_event(Event.SHOWN_IMAGE_CHANGED)
 
+    def create_warning(self, msg: str):
+        print(f"Warning: {msg}")
+        messagebox.showwarning("Warning: ", msg)
+
     def move_absolute(self, coords: dict[str, float]):
-        self.hardware.stage.move_to(coords)
-        x = coords.get("x", self.stage_setpoint[0])
-        y = coords.get("y", self.stage_setpoint[1])
-        z = coords.get("z", self.stage_setpoint[2])
-        self.stage_setpoint = (x, y, z)
-        self.on_event(Event.STAGE_POSITION_CHANGED)
+        # 0  to  -($13X - $27)   in WPos space
+        if(self.hardware.stage.has_homing()): # debugging statements
+            print(f"Moving to position: {coords}")
+            print(f"Current position: {self.stage_setpoint[0]}, {self.stage_setpoint[1]}, {self.stage_setpoint[2]}")
+        
+        # find new coordinates -> some nuance exists between work and gui positioning
+        # in work position, the x moves in negative direction (away from home) and y moves in positive direction (away from home)
+        x = coords.get("x", 0)
+        y = coords.get("y", 0)
+        z = coords.get("z", 0)
+        set_point = (x, y, z)
+
+        if(self.hardware.stage.has_homing()): # if soft limits and max travel set, then enforce boundaries
+            print(f"New position: {set_point}") # debugging statements
+            max_x = -self.hardware.stage.configuration[130] * 1000 + self.hardware.stage.configuration[27] * 1000
+            max_y = self.hardware.stage.configuration[131] * 1000 - self.hardware.stage.configuration[27] * 1000 
+            max_z = -self.hardware.stage.configuration[132] * 1000 + self.hardware.stage.configuration[27] * 1000 
+
+            # Check bounds
+            if not (max_x <= set_point[0] <= 0):
+                self.create_warning(f"Moving X to {x} prohibited. Absolute x boundaries are between {0} and {max_x}")
+                return
+            if not (max_y >= set_point[1] >= 0):
+                self.create_warning(f"Moving Y to {y} prohibited. Absolute y boundaries are between {0} and {max_y}")
+                return
+            if not (max_z <= set_point[2] <= 0):
+                self.create_warning(f"Moving Z to {z} prohibited. Absolute z boundaries are between {0} and {max_z}")
+                return
+
+        try:
+            self.hardware.stage.move_absolute(coords)
+            self.stage_setpoint = set_point
+            self.on_event(Event.STAGE_POSITION_CHANGED)
+        
+        except(RuntimeError) as e:
+            self.create_warning(f"{str(e)}. Please remove your chip, restart the program.")
+
+        except(Exception) as e:
+            self.create_warning(f"{str(e)}. Please remove your chip, restart the program.")
+            self.stage_setpoint = self.hardware.stage.get_position()
+            self.on_event(Event.STAGE_POSITION_CHANGED) 
 
     def move_relative(self, coords: dict[str, float]):
-        x = coords.get("x", 0) + self.stage_setpoint[0]
-        y = coords.get("y", 0) + self.stage_setpoint[1]
-        z = coords.get("z", 0) + self.stage_setpoint[2]
-        self.stage_setpoint = (x, y, z)
-        self.hardware.stage.move_to({k: self.stage_setpoint[i] for k, i in (("x", 0), ("y", 1), ("z", 2))})
-        self.on_event(Event.STAGE_POSITION_CHANGED)
+
+        if(self.hardware.stage.has_homing()): # debugging statements
+            print(f"Moving: {coords}")
+            print(f"Current position: {self.stage_setpoint[0]}, {self.stage_setpoint[1]}, {self.stage_setpoint[2]}")
+        # find new coordinates -> some nuance exists between work and gui positioning
+        # in work position, the x moves in negative direction (away from home) and y moves in positive direction (away from home
+        x = self.stage_setpoint[0] + coords.get("x", 0)
+        y = self.stage_setpoint[1] + coords.get("y", 0)
+        z = self.stage_setpoint[2] + coords.get("z", 0)
+        set_point = (x, y, z)
+        
+        # if soft limits and max travel set, then enforce boundaries
+        if(self.hardware.stage.has_homing()):
+            print(f"New position: {set_point}") # debugging statements
+            max_x = -self.hardware.stage.configuration[130] * 1000 + self.hardware.stage.configuration[27] * 1000
+            max_y = self.hardware.stage.configuration[131] * 1000 - self.hardware.stage.configuration[27] * 1000 
+            max_z = -self.hardware.stage.configuration[132] * 1000 + self.hardware.stage.configuration[27] * 1000 
+
+            # Check bounds
+            if not (max_x <= set_point[0] <= 0):
+                self.create_warning(f"Moving X by {x} prohibited. Absolute x boundaries are between {0} and {max_x}")
+                return
+            if not (max_y >= set_point[1] >= 0):
+                self.create_warning(f"Moving Y by {y} prohibited. Absolute y boundaries are between {0} and {max_y}")
+                return
+            if not (max_z <= set_point[2] <= 0):
+                self.create_warning(f"Moving Z by {z} prohibited. Absolute z boundaries are between {0} and {max_z}")
+                return
+
+        try:
+            self.hardware.stage.move_relative(coords)
+            self.stage_setpoint = set_point
+            self.on_event(Event.STAGE_POSITION_CHANGED)
+
+        except(RuntimeError) as e:
+            self.create_warning(f"{str(e)}. Please remove your chip, restart the program.")
+
+        except(Exception) as e:
+            self.create_warning(f"{str(e)}. Please remove your chip, restart the program.")
+            self.stage_setpoint = self.hardware.stage.get_position()
+            self.on_event(Event.STAGE_POSITION_CHANGED) 
 
     def set_use_solid_red(self, use: bool):
         self.use_solid_red = use
@@ -501,17 +575,21 @@ class EventDispatcher:
         return self.shown_image in (ShownImage.PATTERN, ShownImage.UV_FOCUS)
 
     def home_stage(self):
+        """
+        Homing stage resets Machine position (Mpos) and sets Work Position (WPos)
+        of current state post-homing to (0, 0, 0), which means set_point must 
+        be updated to reflect the work position
+        """
         self.hardware.stage.home()
-        self.non_blocking_delay(1.0)
-        while True:
-            self.non_blocking_delay(1.0)
-            idle, pos = self.hardware.stage._query_state()
-            if idle:
-                break
+        self.hardware.stage.set_on_start_location()
+        print(f"Post Homing Location: {self.hardware.stage.get_on_start_location()}")
+        print("Homing Complete.")
 
-        self.stage_setpoint = (pos[0] * 1000.0, pos[1] * 1000.0, pos[2] * 1000.0)
-        print(f"Homed stage to {self.stage_setpoint}")
         self.on_event(Event.STAGE_POSITION_CHANGED)
+    
+    def query_config(self):
+        self.hardware.stage._query_config()
+        print("Query Config Complete.")
 
     def set_image_position(self, x, y, t):
         self.image_adjust_position = (x, y, t)
@@ -647,6 +725,12 @@ class EventDispatcher:
             except FileExistsError:
                 pass
             log_file = open('aftest/log.csv', 'w')
+        
+        if self.hardware.stage.has_homing():
+            # temporarily hold off on autofocus with homing enabled due to position boundary limits
+            # TODO: CMU S26 Stepper team will create a PR for new autofocus algorithm with homing enabled
+            self.create_warning("With homing enabled, autofocus won't work optimally, please focus manually.")
+            return
         
         counter = 0
         def sample_focus():
@@ -896,7 +980,7 @@ class CameraFrame:
         self.gui_img = gui_img
 
 class StagePositionFrame:
-    def __init__(self, parent, event_dispatcher, uvmode):
+    def __init__(self, parent, event_dispatcher: EventDispatcher, uvmode):
         self.frame = ttk.Frame(parent)
         self.event_dispatcher = event_dispatcher
         
@@ -991,10 +1075,14 @@ class StagePositionFrame:
         self.shortcut_frame.grid(row=2, column=0, columnspan=2, pady=5, sticky="ew")
         
         def on_chip_origin():
-            event_dispatcher.move_absolute({"x": -14500.0, "y": -13500.0, "z": -13844.0})
+            origin = event_dispatcher.hardware.stage.get_on_start_location()
+            event_dispatcher.move_absolute({"x": origin[0], "y": origin[1], "z": origin[2]})
         
         def on_chip_unload():
-            event_dispatcher.move_absolute({"x": -14500.0, "y": -14500.0, "z": -14500.0})
+            """
+            As of now, home position is actually the most optimal place to be removed the chip
+            """
+            on_chip_origin()
         
         btn_state = "normal" if event_dispatcher.hardware.stage.has_homing() else "disabled"
         self.chip_origin_button = ttk.Button(self.shortcut_frame, text="Chip origin", 
@@ -1004,13 +1092,6 @@ class StagePositionFrame:
         self.chip_unload_button = ttk.Button(self.shortcut_frame, text="Load/unload", 
                                             command=on_chip_unload, state=btn_state)
         self.chip_unload_button.grid(row=0, column=1, padx=5)
-    
-    # def _on_set_position(self):
-    #     """Handle the Set Position button click"""
-    #     x = self.position_inputs[0].get()
-    #     y = self.position_inputs[1].get()
-    #     z = self.position_inputs[2].get()
-    #     self.event_dispatcher.move_absolute({"x": x, "y": y, "z": z})
 
     def _position(self) -> tuple[int, int, int]:
         return tuple(intput.get() for intput in self.position_intputs)
@@ -2526,6 +2607,7 @@ class TilingFrame:
             y_amount = abs(y_amount)
 
             x_start, y_start = self.model.stage_setpoint[0], self.model.stage_setpoint[1]
+            print(f"x_start {x_start}, y_start = {y_start}")
           
             #Move in Snake pattern with left to right on even rows and right to left on odd rows
             for y_idx in range(y_amount):
@@ -3008,7 +3090,11 @@ class LithographerGui:
             self.event_dispatcher.enter_red_mode(mode_switch_autofocus=False) # ensure exposure settings are correctly set
             if self.event_dispatcher.hardware.stage.has_homing():
                 self.event_dispatcher.home_stage()
-                #self.event_dispatcher.move_relative({"x": 5000.0, "y": 3500.0, "z": 1900.0})
+                self.event_dispatcher.query_config()
+
+            self.event_dispatcher.stage_setpoint = self.event_dispatcher.hardware.stage.get_position()
+            print(f"Current GUI Location: {self.event_dispatcher.stage_setpoint}")
+
             messagebox.showinfo(
                 message="BEFORE CONTINUING: Ensure that you move the projector window to the correct display! Click on the fullscreen, completely black window, then press Windows Key + Shift + Left Arrow until it no longer is visible!"
             )
@@ -3053,7 +3139,7 @@ def main():
     if stage_config["enabled"]:
         serial_port = serial.Serial(stage_config["port"], stage_config["baud-rate"])
         print(f"Using serial port {serial_port.name}")
-        stage = GrblStage(serial_port, stage_config["homing"])
+        stage = GrblStage(serial_port, stage_config["homing"], stage_config["tiling"], stage_config["autofocus"])
     else:
         stage = StageController()
 
@@ -3120,7 +3206,7 @@ def main():
         camera_scale,
         red_exposure,
         uv_exposure,
-        alignment_config,
+        alignment_config
     )
 
     lithographer = LithographerGui(lithographer_config)

--- a/src/stage_control/grbl_stage.py
+++ b/src/stage_control/grbl_stage.py
@@ -2,10 +2,10 @@
 # J. Kent Wirant
 # GRBL Stage Controller
 
+from collections import defaultdict
 import time
 
 from stage_control.stage_controller import StageController, UnsupportedCommand
-
 
 def clamp(value, lo, hi):
     if value > hi:
@@ -15,66 +15,326 @@ def clamp(value, lo, hi):
     else:
         return value
 
-
 class GrblStage(StageController):
     # only x, y, and z axes are supported by this interface
     # may support alternative axes schemes in the future
     # controller_target must be an open file (may be serial port for example)
-    def __init__(self, controller_target, enable_homing):
+    def __init__(self, controller_target, enable_homing, enable_tiling, autofocus_offset):
         self.controller_target = controller_target
-        self.enable_homing = enable_homing
+        self.enable_homing = enable_homing # homes on start
+        self.enable_tiling = enable_tiling # allow for tiling feature that requires homing
+        self.autofocus_estimate = autofocus_offset # a value offset that estimates current focus z-coordinates
+        self.valid_position = True
+        self.configuration = None
+        self.on_start_location = (0,0,0)
+
+        # Doing checks to ensure quality of following features
+        if self.enable_tiling and not self.enable_homing: 
+            raise RuntimeError("Error: Tiling enabled, but homing is not. Homing is required. Please change config and restart.")
+    
+        if self.autofocus_estimate != 0 and not self.enable_homing:
+            raise RuntimeError("Error: Autofocus set, but homing is not. Homing is required. Please change config and restart.")
 
         time.sleep(3.0) # allow time for grbl to boot
         print(self.controller_target.read_all())
 
         self.axes = ("x", "y", "z")
-
         self.resp_buffer = b""
-
-        print(self._query_state())
-
+        
+        print(f"WPos startup (mm): {self._query_state()}") # queries for current position and state
+        
     def _fill_resp_buffer(self):
         self.resp_buffer += self.controller_target.read_all()
+    
+    def _wait_for_idle(self, timeout=10):
+        """
+        To ensure we are accurantely moving the stage, we'll only send
+        GRBL the next move command when it is ready to take in more commands
+        This means we will return if we're no longer idle
+        """
+        deadline = time.time() + timeout
+
+        while time.time() < deadline:
+            while b"\r\n" not in self.resp_buffer:
+                self._fill_resp_buffer()
+
+            raw, self.resp_buffer = self.resp_buffer.split(b"\r\n", 1)
+            line = raw.decode("ascii", errors="replace").strip()
+            self.resp_buffer = b""
+
+            if not line:
+                continue
+
+            if line.startswith("<") and "Idle" in line:
+                return
+
+            # ignore everything else (but don't lose it if you need it!)
+            raise TimeoutError("Stage did not reach idle")
+
+    def _handle_alarms(self, response):
+        """
+        GRBL Alarm codes:
+            ALARM:1  - Hard limit triggered
+            ALARM:2  - Soft limit triggered  
+            ALARM:3  - Reset while in motion
+            ALARM:4  - Probe fail (initial state open)
+            ALARM:5  - Probe fail (contact not detected)
+            ALARM:6  - Homing fail (reset during cycle)
+            ALARM:7  - Homing fail (door opened during cycle)
+            ALARM:8  - Homing fail (failed to clear limit switch)
+            ALARM:9  - Homing fail (could not find limit switch)
+        """
+
+        code = None
+        if ":" in response:
+            try:
+                code = int(response.split(":")[1].strip())
+            except ValueError:
+                pass  
+        
+        try:
+            self.soft_reset() # soft reset and unlock first
+        except (Exception, RuntimeError, TimeoutError, ValueError) as e:
+            print(f"Error: {str(e)}")
+            return
+
+
+        # GRBL alarms -> Once in alarm-mode, Grbl will lock out and shut down everything until the user issues a reset
+        # --- Soft limit (ALARM:2) ---
+        if code == 2:
+            self.resp_buffer = b""
+            raise RuntimeError(
+                "Soft limit reached — motion outside machine bounds. "
+                "Stage has been reset. Move away from boundary before retrying."
+            )
+
+        # --- Hard limit (ALARM:1) ---
+        elif code == 1:
+            self.resp_buffer = b""
+            raise RuntimeError(
+                "Hard limit triggered — a physical limit switch was hit. "
+                "Check stage position and mechanical state before continuing."
+            )
+
+        # --- Homing failures (ALARM:6-9) ---
+        elif code in (6, 7, 8, 9):
+            self.resp_buffer = b""
+            raise RuntimeError(
+                f"Homing failure ({response}) — homing cycle did not complete. "
+                "Check limit switches and wiring."
+            )
+
+        # --- Reset while in motion (ALARM:3) ---
+        elif code == 3:
+            self.resp_buffer = b""
+            self.valid_position = False
+            raise RuntimeError(
+                "GRBL was reset while the stage was moving. "
+                "Position may be lost — rehome before continuing."
+            )
+
+        # --- Probe failures (ALARM:4-5) ---
+        elif code in (4, 5):
+            # probe alarms don't necessarily require a full reset
+            # since your lithostepper may not use probing, raise clearly
+            self.resp_buffer = b""
+            raise RuntimeError(
+                f"Probe failure ({response}) — check probe wiring and initial state."
+            )
+
+        # --- Any other that we didn't cover ---
+        else:
+            self.resp_buffer = b""
+            raise RuntimeError(
+                f"Unknown GRBL alarm: {response!r}. "
+                "See https://docs.lightburnsoftware.com/legacy/Troubleshooting/GRBLErrors"
+            )
 
     def _send_msg(self, msg: bytes):
-        self.controller_target.write(msg)
-        while b"\r\n" not in self.resp_buffer:
-            self._fill_resp_buffer()
-        resp, self.resp_buffer = self.resp_buffer.split(b"\r\n", maxsplit=1)
-        if resp != b"ok":
-            raise Exception(f"not ok!!! {resp}")
+        """
+        sending g-code command
+        Note: to learn more about error and alarm handling mechanisms, please
+        visit https://github.com/grbl/grbl/wiki//Interfacing-with-Grbl#streaming-a-g-code-program-to-grbl
+        to understand how to unlock out of locked stage, or how to interface with grbl via g-code
 
+        Message Handling: \\
+        Most of the feedback from Grbl fits into nice categories. Here's how they are organized:
+
+            - ok: Standard all-is-good response to a single line sent to Grbl.
+            - error: Standard error response to a single line sent to Grbl.
+            - ALARM: A critical error message that occurred. All processes stopped until user acknowledgment.
+            - []: All feedback messages are sent in brackets (parameter and g-code parser state print-outs)
+            - <>: Status reports are sent in chevrons.
+        """
+        self.controller_target.write(msg) # write gcode command
+        deadline = time.time() + 30.0
+        while True:
+            while b"\r\n" not in self.resp_buffer: # sometimes grbl may take time to respond, so we wait until
+                self._fill_resp_buffer()             # the response actually arrives. This is really important.
+                if time.time() > deadline:
+                    raise TimeoutError("No response from GRBL")      
+                time.sleep(0.01)  # yield the CPU
+
+            resp = self.resp_buffer.split(b"\r\n")
+            self.resp_buffer = b""
+            response = [res.decode("ascii", errors="replace").strip() for res in resp]
+
+            for item in response:
+                if not item:
+                    continue  # skip blank lines
+                elif item.startswith("[") or item.startswith("<"):
+                    print(f"[GRBL feedback]: {item}")
+                    continue  # keep waiting for ok/error
+                if "ok" in item:
+                    print("Received OK")
+                    return  # happy path, command completed, successful
+                elif item.startswith("error:"):
+                    print(f"[GRBL error]: {item}")
+                    return # not going to block normal operations, command blocked, session stays active
+                elif item.upper().startswith("ALARM:"):
+                    self._handle_alarms(item)
+                    return
+                else:
+                    print(f"[GRBL unknown]: {item}")
+                    continue
+        
     def _query_state(self):
-        self.controller_target.write(b"?")
+        """
+        Status Report: \
+        
+        - MPos:0.000,0.000,0.000: Machine position listed as X,Y,Z coordinates. 
+            - Machine Position (MPos): This is the "Absolute" coordinate system
+            - defined entirely by your homing cycle -> often will see negative 
+            - values here because (0,0,0) is location where all proximity sensors light up
+            - and so it "bounces" away from that a bit and that's your homing process
+            - this "bounce" is defined by ($27)
+
+        - WPos:0.000,0.000,0.000: Work position listed as X,Y,Z coordinates. 
+            - Work Position = Machine Position - Work Offset
+
+        - Buf:0: Number of motions queued in Grbl's planner buffer.
+        - RX:0: Number of characters queued in Grbl's serial RX receive buffer.
+
+        $10=0 => WPos only
+        $10=1 => MPos only
+        $10=2 => MPos + WCO (work coordinate offset)
+
+        Example response: `<Idle,MPos:0.000,0.000,0.000,WPos:0.000,0.000,0.000>`
+        """
+        self.controller_target.write(b"?\n")
+
         while b">\r\n" not in self.resp_buffer:
             self._fill_resp_buffer()
-        resp, self.resp_buffer = self.resp_buffer.split(b">\r\n", maxsplit=1)
-        resp = resp.decode("ascii")
-        print(repr(resp))
-        print(len(self.resp_buffer), self.controller_target.in_waiting)
+
+        resp_raw = self.resp_buffer.split(b"<")[1].split(b">")[0]
+        buff = resp_raw.decode("ascii", errors="replace").strip()
+        self.resp_buffer = b""
+
         idle = False
-        for part in resp.split("|"):
+        position = None
+        work_position = None
+
+        for part in buff.split("|"):
             if "Idle" in part:
                 idle = True
             elif part.startswith("MPos:"):
                 x, y, z = part.removeprefix("MPos:").split(",")
                 position = (float(x), float(y), float(z))
+            elif part.startswith("WPos:"):
+                x, y, z = part.removeprefix("WPos:").split(",")
+                work_position = (float(x), float(y), float(z))
+        
+        resolved_position = position or work_position
+        print(f"resolved position: {resolved_position}, Idle: {idle}")
+        if resolved_position is None:
+            raise ValueError(f"GRBL status response contained no position data: {buff!r}")
+        return idle, resolved_position
+    
+    def _query_config(self):
+        """
+        queries for entire grbl settings ->
+        $0=10 (Step pulse time, microseconds) \n
+        $1=25 (Step idle delay, msec) \n
+        $2=0 (Step pulse invert, mask) \n
+        $3=0 (Step direction invert, mask) \n
+        $4=0 (Invert step enable pin, boolean)\n
+        $5=0 (Invert limit pins, boolean)\n
+        $6=0 (Invert probe pin, boolean)\n
+        $10=1 (Status report options, mask) \n
+        $11=0.010 (Junction deviation, mm) \n
+        $12=0.002 (Arc tolerance, mm) \n
+        $13=0 (Report inches, boolean) \n
+        $20=0 (Soft limits enable, boolean) \n
+        $21=0 (Hard limits enable, boolean) \n
+        $22=0 (Homing cycle enable, boolean) \n
+        $23=0 (Homing direction invert, mask) \n
+        $24=25.000 (Homing locate feed rate, mm/min) \n
+        $25=500.000 (Homing search seek rate, mm/min) \n
+        $26=250 (Homing switch debounce delay, msec) \n
+        $27=1.000 (Homing switch pull-off distance, mm) \n
+        $30=1000 (Max spindle speed, RPM) \n
+        $31=0 (Min spindle speed, RPM) \n
+        $32=0 (Laser mode enable, boolean) \n
+        $100=250.000 (X steps/mm) \n
+        $101=250.000 (Y steps/mm) \n
+        $102=250.000 (Z steps/mm) \n
+        $110=500.000 (X max rate, mm/min) \n
+        $111=500.000 (Y max rate, mm/min) \n
+        $112=500.000 (Z max rate, mm/min) \n
+        $120=10.000 (X acceleration, mm/sec^2) \n
+        $121=10.000 (Y acceleration, mm/sec^2) \n
+        $122=10.000 (Z acceleration, mm/sec^2) \n
+        $130=200.000 (X max travel, mm) \n
+        $131=200.000 (Y max travel, mm) \n
+        $132=200.000 (Z max travel, mm) \n
+        """
+        print("Querying GRBL configurations")
+        self.configuration = {}
+        self.resp_buffer = b""
+        self.controller_target.write(b"$$\n")
+        lines = []
 
-        return idle, position
+        # fetch entire configuration for grbl
+        while b"ok" not in self.resp_buffer:
+            self._fill_resp_buffer()
+        raw = self.resp_buffer.split(b"\r\n")
+        self.resp_buffer = b""
+        buff = [r.decode("ascii", errors="replace").strip() for r in raw]
+        
+        # parse the buffer
+        for setting in buff:
+            if not setting or '$' not in setting:
+                continue
+            if "ok" in setting:
+                break
+            if setting.startswith("error:"):
+                raise Exception(f"GRBL error: query config failed -> {setting}") # double check this
+            lines.append(setting)
+        
+        # parse string splits
+        for line in lines:
+            if "$" in line:
+                part = line.split("$")[-1].strip() # => [0=10]
+                if "=" in part:
+                    key, value = part.split("=", 1)
+                    key = int(key.strip())
+                    value = value.strip()
+                    if value == "":
+                        value = None
+                    elif "." in value:
+                        value = float(value)
+                    else:
+                        value = int(value)
+                    self.configuration[key] = value
+        print("Done extracting configuration")
+        print(self.configuration)
 
     def __del__(self):
         self._send_msg(b"G91\n")
 
-    def has_homing(self):
-        return self.enable_homing
-
-    def home(self):
-        if self.enable_homing:
-            self._send_msg(b"$H\n")
-        else:
-            raise UnsupportedCommand()
-
     def _move(self, microns: dict[str, float], relative):
+
+        # Note: depending on $10, G91 and G90 will move wrt WPos or MPos
         if relative:
             self._send_msg(b"G91\n")
         else:
@@ -91,23 +351,151 @@ class GrblStage(StageController):
             z_mm = microns["z"] / 1000.0
             msg += f" z{z_mm:.3f}"
         msg += "\n"
-
+        
         self._send_msg(msg.encode("ascii"))
-
+    
     def move_relative(self, microns: dict[str, float]):
+        """
+        Moves relative to WPos
+
+        Pre-conditions if homing enabled:
+        0 >= microns[0] >= -$130   (for X)
+        0 >= microns[1] >= -$131   (for Y)
+        0 >= microns[2] >= -$132   (for Z)
+        """
+        if not self.valid_position and self.enable_tiling: # only block if users are doing tiling
+            raise RuntimeError("Position is invalid — please exit and re-open the application.")
+        
         print("moving relative", microns)
         self._move(microns, relative=True)
 
     def move_absolute(self, microns: dict[str, float]):
+        """
+        Moves to absolute location in WPos
+
+        Pre-conditions if homing enabled:
+        0 >= microns[0] >= -$130   (for X)
+        0 >= microns[1] >= -$131   (for Y)
+        0 >= microns[2] >= -$132   (for Z)
+        """
+        if not self.valid_position and self.enable_tiling: # only block if users are doing tiling
+            raise RuntimeError("Position is invalid — please exit and re-open the application.")
+        
         print("moving absolute", microns)
         self._move(microns, relative=False)
+    
+    def soft_reset(self):
+        """ 
+        This is used when handling GrblAlarm that locks GRBL interface and disallows
+        us from sending more g-code messages, thereby creating a freezing gui interface. 
+        Steps to unlock include a full soft reset, and an unlock g-code command to escape out
+        """
+        self.controller_target.write(b"\x18")  # soft reset
+        
+        deadline = time.time() + 5.0
+        startup_seen = False
 
-    def move_by(self, amounts):
-        self.move_relative(amounts)
+        while time.time() < deadline:
+            self.resp_buffer += self.controller_target.read_all()
+            if b"Grbl" in self.resp_buffer:
+                startup_seen = True
+                break
+            time.sleep(0.05)
+        
+        if not startup_seen:
+            raise RuntimeError("GRBL did not send startup greeting after reset — check connection.")
 
-    def move_to(self, amounts):
-        self.move_absolute(amounts)
+        self.resp_buffer = b""
 
+        deadline = time.time() + 3.0
+        while time.time() < deadline:
+            self.resp_buffer += self.controller_target.read_all()
+            if b"\r\n" in self.resp_buffer:
+                break
+            time.sleep(0.05)
+
+        resp, self.resp_buffer = self.resp_buffer.split(b"\r\n", maxsplit=1)
+        response = resp.decode("ascii", errors="replace").strip()
+
+        if response != "ok":
+            raise RuntimeError(f"GRBL unlock ($X) failed — got: {response!r}")
+
+        self.resp_buffer = b""
+        print("Stage Reset and Unlocked")
+    
+    def home(self):
+        """
+        Homes the stage (assume proximity sensors exist for each axis, then sets WPos
+        to the homed location that is $27 mm away from absolute MPos (0,0,0). Now
+        the users will see the location post-homing as (0,0,0)
+
+        NOTE: Maximum distance of homing seek travel per axis is 1.5 times its configured max travel,
+        which basically guarantees that we can find home if soft limits are set. So ensure soft limits
+        are enabled to home deterministically (works 99% of the time)
+        - To change max travel: set $130-$132
+        - To change soft limits: set $20=1
+        
+        When $H runs, GRBL moves all axes toward their endstops until the limit switches trigger. 
+        Then it pulls off by $27 (pull-off distance, default 1mm). After that sequence completes, 
+        GRBL automatically sets MPos to (0,0,0) at the endstop location internally.
+
+        Because of pull-off dinstance, you may see MPos at a negative location upon sending a ?
+        right after homing. 
+
+        Because MPos can sometimes contain random values (which makes sense), we want to set a 
+        WPos, which allows us to set the (0,0,0) position to any location we're at. This is just
+        so developers and gui users find it easier to work off of coordinates with an origin of (0,0,0)
+
+        For more info, please visit GRBL documentation wiki. 
+
+        """
+        print("Sending Home Command...")
+        if self.enable_homing:
+            self._send_msg(b"$H\n")
+            print("Storing Location to Home...")
+
+            # "pinning" WPos (0,0,0) to the physical end-stops (limit switch locations)
+            # MPos = (some triplet of negative values depending on $27)
+            # WPos = (0,0,0) -> establish current position as home (0,0,0)
+            self._send_msg(b"G10 L20 P1 X0 Y0 Z0\n") 
+            self.valid_position = True
+                
+        else:
+            raise UnsupportedCommand()
+    
+    def set_on_start_location(self):
+        self.on_start_location = self.get_position()
+        
+    def has_homing(self) -> bool:
+        return self.enable_homing
+
+    def get_autofocus(self) -> float:
+        """
+        Returns offset from z-axis home coordinate
+        that can get the stage to reach an estimated
+        focused position. 
+
+        Note: developers will still need to run their custom 
+        autofocus function that can fine-tune the focus score,
+        but this provides a good point to start the gradient
+        descent search. 
+        """
+        return self.autofocus_estimate
+        
+    def get_position(self) -> tuple[float, float, float]:
+        """
+        Returns GUI / Wpos of stage in microns
+        IMPORTANT: WPos is different from MPos, so
+        ensure that $10 is set to reveal WPos instead of MPos
+        """
+        _, positions = self._query_state() # in microns
+        micron_x = positions[0] * 1000
+        micron_y = positions[1] * 1000
+        micron_z = positions[2] * 1000
+        return (micron_x, micron_y, micron_z)
+    
+    def get_on_start_location(self) -> tuple[float, float, float]:
+        return self.on_start_location
     """
     # pass in list of amounts to move by. Dictionary in "axis: amount" format
     def move_by(self, amounts: dict[str, float]):

--- a/src/stage_control/stage_controller.py
+++ b/src/stage_control/stage_controller.py
@@ -17,6 +17,28 @@ class StageController:
 
     def has_homing(self):
         return False
-
+    
     def home(self):
-        raise UnsupportedCommand()
+        print(f"ignoring home() in dummy_stage controller")
+    
+    def move_relative(self, microns: dict[str, float]):
+        print(f"ignoring move_relative {microns} in dummy_stage controller")
+
+    def move_absolute(self, microns: dict[str, float]):
+        print(f"ignoring move_absolute {microns} in dummy_stage controller")
+
+    def soft_reset(self):
+        print(f"ignoring soft_reset in dummy_stage controller")
+    
+    def set_on_start_location(self):
+        print(f"ignoring set_on_start_location in dummy_stage controller")
+
+    def get_autofocus(self):
+        print(f"ignoring get_autofocus in dummy_stage controller")
+
+    def get_position(self):
+        print(f"ignoring get_position in dummy_stage controller")
+    
+    def get_on_start_location(self):
+        print(f"ignoring get_on_start_location in dummy_stage controller")
+


### PR DESCRIPTION
# Main issues we fix
- [x] fix homing in grbl configuration using UGS
- [x] stores grbl configuration settings in class instance so it's accessible and eventually customizable
- [x] corrected homing configuration over GRBL g-code interface (update README.md)
-  [x] better error handling for GRBL exceptions (alarms and errors). Instead of freezing stage movement and locking the stage, we gracefully handle these errors by notifying users of error 
- [x] provide a warning if user wants to move the stage to somewhere outside the boundaries and tell them which axis is breaking that boundary
- [x] update `on_chip_origin()`  and `unload_chip()` buttons so they don't have hard-coded postiions to go back to. 

## Config Note
toml files should have updated keys under `[stage]` so please check the README for what to add before trying to run the software. Thanks! 

## GRBL Config changes
Homing enabled, soft limits enabled, Status report changed to WPos format, Max travel distance for all axes changed to your liking, Homing direction adjusted to what fits your system. 

## Note
If you aren't using proximity sensors or limit switches, please don't enable homing unless you know what you're doing. 

Homing must be enabled in GRBL. You can use UGS interface to set this. Additionally, if you wish to use homing, ensure that the homing directions are configured correctly such that the homing direction per-axis moves towards the sensors. 

Next, I switched $10 configuration to show WPos instead of MPos for better abstraction between firmware and gui

Last, setting boundaries for each axis is much easier done in the gui software, so setting hard or soft limits is really not necessary, but good practice. So I recommend soft limits at least (since they raise errors and not alarms, see grbl wiki for more info). 

## Example of Boundary Warning:

![IMG_6049 (1)](https://github.com/user-attachments/assets/512f5587-42c5-4b77-a46a-a9eedc3192e0)

## Example of software startup with homing enabled

![IMG_6048](https://github.com/user-attachments/assets/8b0d84dd-94dc-461c-ad16-4f761f89a233)
