### PR TITLE
RF-DETR alignment marker detection model (supports latent & developed image detection)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.onnx filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -154,6 +154,23 @@ python --version          # ensure version is correct (<=3.10)
 pip install -r requirements.txt
 ```
 
+## Loading Alignment Markers (RF_DETR model)
+
+Due to file size constraints in GitHub, the actual file for the RF_DETR weights (`weights.onnx`) are not stored
+in this repository, and are instead replaced by a pointer file on a large file system in git (Git LFS)
+In order to extract that file, you have two options:
+
+```bash
+git lfs install
+git clone https://github.com/hacker-fab/stepper
+git lfs pull
+```
+
+> If you already cloned without LFS, you can just run `git lfs pull` to fetch the weights, no need to run the second line.
+
+Alternatively, you may fetch the real file [here](https://drive.google.com/file/d/1gzfTfCEShMwD_rnQ02xfzXXrrkVuZwpM/view?usp=drive_link) and replace the current `weights.onnx` file with the one downloaded from the link. 
+
+
 ### Using a Basler (Pylon) camera
 
 To use a Basler camera with the GUI, you will need to install `pylon` from

--- a/README.md
+++ b/README.md
@@ -58,12 +58,18 @@ Enable homing (if you have sensors).
 $22=1
 ```
 
+Ensure that positions are given as `WPos` instead of `MPos`. This allows
+us to set a (0,0,0) starting point for within grbl itself. Note that this
+is optional, but highly recommened, as it's easier to read coordinates 
+from grbl this way.
+
 Adjust the homing direction invert mask (if you have sensors).
 Bits 0, 1, and 2 in this value correspond to the X, Y, and Z axes.
 For each axis, check if the limit switch is reached by moving in the positive direction or the negative direction.
 If the axis requires negative movement, set the corresponding bit.
 On CMU's setup, the limit switches are all reached by traveling in the negative direction,
-so we use a value of 7 (invert all axes).
+so we use a value of 7 (invert all axes). However this value may change
+depending on how you also configure setting `$3`. 
 
 ```
 $23=7
@@ -220,9 +226,16 @@ uv-exposure = 25000.0
 enabled = true
 # Set homing to false if your stage does not have limit sensors
 homing = false
+
+# The following features can be enabled when homing 
+# is set to true. Note that this assumes the stage
+# won't be moved manually, but entirely through the gui
+
 # Enable tiling if user wishes to use tiling features
 tiling = false
-# Set autofocus offset, requires homing to be true. Set 0 for no autofocus 
+# Set autofocus offset to get an estimated focus position
+# for the z-stage. Set 0 to use the original autofocus
+# algorithm, which may take more time to run. 
 autofocus = 0
 
 
@@ -236,8 +249,13 @@ baud-rate = 115200
 [alignment]
 # Enable or disable real-time detection of alignment markers
 enabled = false
-# Path to the YOLO model weights file
-model_path = "best.pt"
+# Path to the alignment model weights file
+# The following paths are supported: "ckpts/best.pt" and "ckpts/weights.onnx"
+# The key difference between the two are that best.pt runs a YOLO model trained on developed
+# images while weights.onnx runs on RF-DETR, which is trained on both developed and latent images
+# that suite it for the tiling feature for the stepper
+model_path = "ckpts/best.pt"
+
 # Alignment marker reference coordinates (in pixels)
 right_marker_x = 1634.0  # x-coordinate for markers on the right side
 top_marker_y = 117.5     # y-coordinate for markers on the top

--- a/ckpts/weights.onnx
+++ b/ckpts/weights.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ceb7afeb340d46c2fd671f9532db16a6dd23e8fd85a60adec3c1b97cd5042cd8
+size 121571388

--- a/default.toml
+++ b/default.toml
@@ -21,15 +21,20 @@ uv-exposure = 25000.0
 [stage]
 # Set enabled to false to disable all motion.
 enabled = true
-
 # Set homing to false if your stage does not have limit sensors
 homing = false
 
+# The following features can be enabled when homing 
+# is set to true. Note that this assumes the stage
+# won't be moved manually, but entirely through the gui
+
 # Enable tiling if user wishes to use tiling features
 tiling = false
-
-# Set autofocus offset, requires homing to be true. Set 0 for no autofocus 
+# Set autofocus offset to get an estimated focus position
+# for the z-stage. Set 0 to use the original autofocus
+# algorithm, which may take more time to run. 
 autofocus = 0
+
 
 # Select the correct serial port for the device running GRBL.
 # The correct serial port can be checked with Device Manager on Windows.
@@ -46,8 +51,13 @@ z-max = -1
 [alignment]
 # Enable or disable real-time detection of alignment markers
 enabled = false
-# Path to the YOLO model weights file
+# Path to the alignment model weights file
+# The following paths are supported: "ckpts/best.pt" and "ckpts/weights.onnx"
+# The key difference between the two are that best.pt runs a YOLO model trained on developed
+# images while weights.onnx runs on RF-DETR, which is trained on both developed and latent images
+# that suite it for the tiling feature for the stepper
 model_path = "ckpts/best.pt"
+
 # Alignment marker reference coordinates (in pixels)
 right_marker_x = 1820.0  # x-coordinate for markers on the right side
 top_marker_y = 269.0     # y-coordinate for markers on the top

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pyserial>=3.5",
     "toml>=0.10.2",
     "ultralytics>=8.3.218",
+    "onnxruntime>=1.19.0,<1.22.0"
 ]
 
 [tool.uv.sources]

--- a/src/gui.py
+++ b/src/gui.py
@@ -19,6 +19,7 @@ import cv2
 import numpy as np
 import serial
 import math
+import onnxruntime as rt
 from PIL import Image, ImageOps, ImageTk
 from ultralytics import YOLO
 from camera.camera_module import CameraModule
@@ -32,6 +33,8 @@ from stage_control.omm_stage import OMMStage
 from stage_control.stage_controller import StageController
 
 # TODO: Don't hardcode
+RF_DETR_IMPUT_SIZE = 704
+CONFIDENCE_THRESHOLD = 0.77
 THUMBNAIL_SIZE: tuple[int, int] = (160, 90)
 #The values set here are not used and instead come from the config file
 DEFAULT_RED_EXPOSURE: float = 4167.0
@@ -70,7 +73,6 @@ def compute_focus_score(camera_image, blue_only, save=False):
         print('saved focus: ', np.min(img_lapl), np.max(img_lapl))
         cv2.imwrite(save, img_lapl * 255.0 / 5.0)
     return img_lapl.var() / mean
-
 
 def detect_alignment_markers(model, image, draw_rectangle=False):
     detections = []
@@ -879,6 +881,66 @@ class EventDispatcher:
         self.set_autofocus_busy(False)
         print("Finished autofocus")
     
+    def detect_marks_for_slam(self, img, session):
+        """
+        Detects alignment markers for tiling SLAM algorithm
+        Returns an array of dictionary coordinates:
+        Example: arr[0] = {"center": (x,y), "left":(x,y), "right":(x,y), "top":(x,y), "bottom":(x,y)}
+        """
+        vis = img.copy()
+        orig_h, orig_w = vis.shape[:2]
+        img_resized = cv2.resize(vis, (RF_DETR_IMPUT_SIZE, RF_DETR_IMPUT_SIZE)) # fsr it only accepts one size
+        img_input = img_resized.transpose(2, 0, 1)  # HWC -> CHW
+        img_input = np.expand_dims(img_input, 0).astype(np.float32) / 255.0
+
+        # Run inference
+        input_name = session.get_inputs()[0].name
+        boxes, scores = session.run(None, {input_name: img_input})
+
+        boxes = boxes[0] 
+        scores = scores[0] 
+
+        markers = []
+        for i in range(len(boxes)):
+            class_id = np.argmax(scores[i])
+            confidence = 1 / (1 + np.exp(-scores[i][class_id]))
+            if confidence > CONFIDENCE_THRESHOLD:
+                x, y, w, h = boxes[i]
+                
+                # fetch centers, and scale back to original image size
+                cx = int(x * orig_w)
+                cy = int(y * orig_h)
+                bw = int(w * orig_w)
+                bh = int(h * orig_h)
+
+                marker = {
+                    "center": (cx, cy),
+                    "left":   (cx - bw // 2, cy),
+                    "right":  (cx + bw // 2, cy),
+                    "top":    (cx, cy - bh // 2),
+                    "bottom": (cx, cy + bh // 2)
+                }
+                markers.append(marker)
+                print(f"Detection: class={class_id}, confidence={confidence:.2f} ->\ncoordinates: {marker}\n")
+        return markers
+    
+    def get_model(self, path: str):
+        """
+        Based on which model we're using, we will feed the model
+        a different session. 'best.pt' indicates YOLO while the onx 
+        file indicates RF-DETR
+        
+        Note to developers: RF-DETR was trained on latent and developed patterns
+        while YOLO model was trained on developed patterns only
+        """
+        if "best" in path:
+            print("Using YOLO model")
+            self.model = YOLO(path)
+        else:
+            print("Using RF_DETR model")
+            session = rt.InferenceSession(path)
+        return session
+
     def initialize_alignment(self, config: LithographerConfig):
         self.config = config
         self.realtime_detection = config.alignment.enabled
@@ -886,10 +948,10 @@ class EventDispatcher:
         try:
             print("loading model")
             model_path = config.alignment.model_path
-            self.model = YOLO(model_path)
+            self.model = self.get_model(model_path)
             print("loaded model")
         except Exception as e:
-            print(f"Failed to load YOLO model: {e}")
+            print(f"Failed to load alignment model: {e}")
 
     def set_snapshot_directory(self, directory: Path):
         self.snapshot_directory = directory

--- a/src/gui.py
+++ b/src/gui.py
@@ -233,7 +233,7 @@ class Chip:
 class EventDispatcher:
     hardware: Lithographer
     root: Tk
-    model: Optional[YOLO]
+    model: Optional[YOLO | rt.InferenceSession]
     camera: Optional[CameraModule]
     red_focus: ProcessedImage
     uv_focus: ProcessedImage
@@ -475,9 +475,9 @@ class EventDispatcher:
         
         # find new coordinates -> some nuance exists between work and gui positioning
         # in work position, the x moves in negative direction (away from home) and y moves in positive direction (away from home)
-        x = coords.get("x", 0)
-        y = coords.get("y", 0)
-        z = coords.get("z", 0)
+        x = coords.get("x", self.stage_setpoint[0])
+        y = coords.get("y", self.stage_setpoint[1])
+        z = coords.get("z", self.stage_setpoint[2])
         set_point = (x, y, z)
 
         if self.hardware.stage.has_homing():
@@ -939,7 +939,8 @@ class EventDispatcher:
         else:
             print("Using RF_DETR model")
             session = rt.InferenceSession(path)
-        return session
+            self.model = session
+        return True
 
     def initialize_alignment(self, config: LithographerConfig):
         self.config = config
@@ -948,7 +949,7 @@ class EventDispatcher:
         try:
             print("loading model")
             model_path = config.alignment.model_path
-            self.model = self.get_model(model_path)
+            self.get_model(model_path)
             print("loaded model")
         except Exception as e:
             print(f"Failed to load alignment model: {e}")
@@ -2434,6 +2435,10 @@ class GlobalSettingsFrame:
 
         # Configure grid weights for proper expansion
         self.snapshot_frame.columnconfigure(1, weight=1)
+
+        # Button for new RF-DETR Model's alignment detection
+        self.detect_button = ttk.Button(self.frame, text="Detect Fiducials", command=lambda: event_dispatcher.detect_marks_for_slam(event_dispatcher.camera_image, event_dispatcher.model))
+        self.detect_button.grid(row=3, column=0, sticky="ew")
 
 
 class ExposureHistoryFrame:

--- a/uv.lock
+++ b/uv.lock
@@ -115,6 +115,18 @@ wheels = [
 ]
 
 [[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -307,6 +319,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.60.1"
 source = { registry = "https://pypi.org/simple" }
@@ -370,6 +390,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/e0/bab50af11c2d75c9c4a2a26a5254573c0bd97cea152254401510950486fa/fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19", size = 304847, upload-time = "2025-09-02T19:10:49.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/71/70db47e4f6ce3e5c37a607355f80da8860a33226be640226ac52cb05ef2e/fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7", size = 199289, upload-time = "2025-09-02T19:10:47.708Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
 ]
 
 [[package]]
@@ -910,6 +942,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/72/09d8f206402cd91805828354ad1d7473b1bace60fc54a11971012906d9b7/onnxruntime-1.21.1-cp310-cp310-macosx_13_0_universal2.whl", hash = "sha256:daedb5d33d8963062a25f4a3c788262074587f685a19478ef759a911b4b12c25", size = 33639134, upload-time = "2025-04-18T12:01:11.442Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/66/31384dc7beea89f21ec7d1582c1b50e9d047d505db38f32cf49693fad1b4/onnxruntime-1.21.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a402f9bda0b1cc791d9cf31d23c471e8189a55369b49ef2b9d0854eb11d22c4", size = 14162243, upload-time = "2025-04-18T12:01:34.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/fb/76597b77785b2012317ffdd817101ccfab784e2c125645d002c4c9cd377b/onnxruntime-1.21.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15656a2d0126f4f66295381e39c8812a6d845ccb1bb1f7bf6dd0a46d7d602e7f", size = 16000498, upload-time = "2025-04-18T12:01:36.797Z" },
+    { url = "https://files.pythonhosted.org/packages/91/83/c7287845f22f2e1d37a54b5997e9589b6931e264cc0f16250d1706eadf79/onnxruntime-1.21.1-cp310-cp310-win_amd64.whl", hash = "sha256:79bbedfd1263065532967a2132fb365a27ffe5f7ed962e16fec55cca741f72aa", size = 12300918, upload-time = "2025-04-18T12:01:14.902Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/13c46c22fb52d8fea53575da163399a7d75fe61223aba685370f047a0882/onnxruntime-1.21.1-cp311-cp311-macosx_13_0_universal2.whl", hash = "sha256:8bee9b5ba7b88ae7bfccb4f97bbe1b4bae801b0fb05d686b28a722cb27c89931", size = 33643424, upload-time = "2025-04-18T12:01:17.445Z" },
+    { url = "https://files.pythonhosted.org/packages/18/4f/68985138c507b6ad34061aa4f330b8fbd30b0c5c299be53f0c829420528e/onnxruntime-1.21.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b6a29a1767b92d543091349f5397a1c7619eaca746cd1bc47f8b4ec5a9f1a6c", size = 14162437, upload-time = "2025-04-18T12:01:39.412Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/76/7dfa4b63f95a17eaf881c9c464feaa59a25bbfb578db204fc22d522b5199/onnxruntime-1.21.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:982dcc04a6688e1af9e3da1d4ef2bdeb11417cf3f8dde81f8f721043c1919a4f", size = 16002403, upload-time = "2025-04-18T12:01:41.645Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/397406e758d6c30fb6d0d0152041c6b9ee835c3584765837ce54230c8bc9/onnxruntime-1.21.1-cp311-cp311-win_amd64.whl", hash = "sha256:2b6052c04b9125319293abb9bdcce40e806db3e097f15b82242d4cd72d81fd0c", size = 12301824, upload-time = "2025-04-18T12:01:20.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/274438bbc259439fa1606d0d6d2eef4171cdbd2d7a1c3b249b4ba440424b/onnxruntime-1.21.1-cp312-cp312-macosx_13_0_universal2.whl", hash = "sha256:f615c05869a523a94d0a4de1f0936d0199a473cf104d630fc26174bebd5759bd", size = 33658457, upload-time = "2025-04-18T12:01:22.937Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/93/76f629d4f22571b0b3a29a9d375204faae2bd2b07d557043b56df5848779/onnxruntime-1.21.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79dfb1f47386c4edd115b21015354b2f05f5566c40c98606251f15a64add3cbe", size = 14164881, upload-time = "2025-04-18T12:01:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/86/75cbaa4058758fa8ef912dfebba2d5a4e4fd6738615c15b6a2262d076198/onnxruntime-1.21.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2742935d6610fe0f58e1995018d9db7e8239d0201d9ebbdb7964a61386b5390a", size = 16019966, upload-time = "2025-04-18T12:01:47.366Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9d/fb8895b2cb38c9965d4b4e0a9aa1398f3e3f16c4acb75cf3b61689780a65/onnxruntime-1.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:a7afdb3fcb162f5536225e13c2b245018068964b1d0eee05303ea6823ca6785e", size = 12302925, upload-time = "2025-04-18T12:01:26.147Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/7e/8445eb44ba9fe0ce0bc77c4b569d79f7e3efd6da2dd87c5a04347e6c134e/onnxruntime-1.21.1-cp313-cp313-macosx_13_0_universal2.whl", hash = "sha256:ed4f9771233a92edcab9f11f537702371d450fe6cd79a727b672d37b9dab0cde", size = 33658643, upload-time = "2025-04-18T12:01:28.73Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/46/9c4026d302f1c7e8427bf9fa3da2d7526d9c5200242bde6adee7928ef1c9/onnxruntime-1.21.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bc100fd1f4f95258e7d0f7068ec69dec2a47cc693f745eec9cf4561ee8d952a", size = 14165205, upload-time = "2025-04-18T12:01:50.117Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b2/4e4c6b5c03be752d74cb20937961c76f53fe87a9760d5b7345629d35bb31/onnxruntime-1.21.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0fea0d2b98eecf4bebe01f7ce9a265a5d72b3050e9098063bfe65fa2b0633a8e", size = 16019529, upload-time = "2025-04-18T12:01:52.995Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/1d/afca646af339cc6735f3fb7fafb9ca94b578c5b6a0ebd63a312468767bdb/onnxruntime-1.21.1-cp313-cp313-win_amd64.whl", hash = "sha256:da606061b9ed1b05b63a37be38c2014679a3e725903f58036ffd626df45c0e47", size = 12303603, upload-time = "2025-04-18T12:01:32.073Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/12/a01e38c9a6b8d7c28e04d9eb83ad9143d568b961474ba49f0f18a3eeec82/onnxruntime-1.21.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94674315d40d521952bfc28007ce9b6728e87753e1f18d243c8cd953f25903b8", size = 14176329, upload-time = "2025-04-18T12:01:55.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/72/5ff85c540fd6a465610ce47e4cee8fccb472952fc1d589112f51ae2520a5/onnxruntime-1.21.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c9e4571ff5b2a5d377d414bc85cd9450ba233a9a92f766493874f1093976453", size = 15990556, upload-time = "2025-04-18T12:01:57.979Z" },
+]
+
+[[package]]
 name = "opencv-python"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
@@ -1029,6 +1094,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1063,6 +1143,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/c7/e4f877d13c3a317760dd4c70e77a31395d2c4fc7b85fb1b31cecbf2b30f1/pypylon-4.1.0-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:54b035b04c7f4c86e9b79207dd00c2805b6dfa14506ca53505bc0b3b72c1795e", size = 70725708, upload-time = "2024-11-25T14:27:42.56Z" },
     { url = "https://files.pythonhosted.org/packages/68/66/b0de0755b9e07a505f4fdbcff37621b2b948ac4f436e76d778921a930875/pypylon-4.1.0-cp39-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:6eaea6c71a0a05da30763e1801b165ffbbdcc590800f3917c979ac5c3b9c53ca", size = 81903026, upload-time = "2024-11-25T13:55:42.151Z" },
     { url = "https://files.pythonhosted.org/packages/10/67/5484d6df0ddeb72e7898082b217a687f8a1343b29c069495f8d36e828146/pypylon-4.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:d8ef3d5ca6b272490a390b103c73c7c4bb995d6957f70d1179ac6a56bc2adfee", size = 89477818, upload-time = "2024-11-25T13:53:24.113Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
 ]
 
 [[package]]
@@ -1332,6 +1421,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "open-micro-stage-api" },
+    { name = "onnxruntime" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pypylon" },
@@ -1342,6 +1432,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "onnxruntime", specifier = ">=1.19.0,<1.22.0" },
     { name = "open-micro-stage-api", git = "https://github.com/hacker-fab/MicroManipulatorStepper/?subdirectory=software%2FPythonAPI" },
     { name = "opencv-python", specifier = ">=4.11.0.86" },
     { name = "pillow", specifier = ">=11.1.0" },


### PR DESCRIPTION
Introducing a new alignment marker detection model that can detect fiducials in both developed chips as well as latent chips (which are chips that have just been patterned and a latent image of the pattern faintly appears in the camera frame) for tiling features

New weights are in `ckpt/` directory, I updated README.md so devs know how to extract the weights file
Additionally, the current function returns the coordinates of the markers with respect to the image capture's coordinates system, not the stage coordinates, so getting absolute position of markers is just current stage pos + detected markers locations

<img width="754" height="274" alt="image" src="https://github.com/user-attachments/assets/44596c14-d869-4282-a446-33abda83b764" />
